### PR TITLE
Fixing the Issue with 'Seen' or 'Not Seen' Pronunciation before reading the message.

### DIFF
--- a/addon/appModules/unigram.py
+++ b/addon/appModules/unigram.py
@@ -928,6 +928,11 @@ class AppModule(appModuleHandler.AppModule):
 			elif item.UIAAutomationId == "HeaderLabel": header = item
 			item = item.next
 
+		# Add the dot after seen or 'not seen' if there are no reactions.
+		if  not reactions:
+			obj.name = obj.name.replace(keywords[0][:-1], keywords[0]).replace(keywords[1][:-1], keywords[1])
+			self.end_text = self.end_text.replace(keywords[0][:-1], keywords[0]).replace(keywords[1][:-1], keywords[1])
+
 		# Checking if a message is a call
 		try:
 			if obj.firstChild.role == Role.LINK and not obj.firstChild.name and obj.childCount == 7 and obj.children[1].UIAAutomationId == "TitleLabel" and obj.children[3].role == Role.STATICTEXT:

--- a/addon/appModules/unigram.py
+++ b/addon/appModules/unigram.py
@@ -965,11 +965,11 @@ class AppModule(appModuleHandler.AppModule):
 					obj.name = obj.name.replace(keywords[1], ".", -1)
 					obj.name = keywords[1][2:]+" "+obj.name
 			
-			if conf.get("voice_the_presence_of_a_reaction") and reactions:
+#			if conf.get("voice_the_presence_of_a_reaction") and reactions:
 				# Announcing reactions if they are contained in the message
-				reactions = [item.name for item in reactions]
-				reactions = _("Reactions")+": "+", ".join(reactions)
-				obj.name += "\n"+reactions
+#				reactions = [item.name for item in reactions]
+#				reactions = _("Reactions")+": "+", ".join(reactions)
+#				obj.name += "\n"+reactions
 
 		obj.name = sender+obj.name
 		# Check if a message is selected


### PR DESCRIPTION
Announcing reactions has been disabled due to their availability within Unigram itself.
Resolved the bug related to pronouncing 'seen' or 'not seen' due to removing the period after them when there are no reactions.